### PR TITLE
fix missing syscalls _exit, _kill, _getpid, ...

### DIFF
--- a/firmware/ChibiOS-ver16.1.9/os/various/syscalls.c
+++ b/firmware/ChibiOS-ver16.1.9/os/various/syscalls.c
@@ -176,4 +176,42 @@ int _isatty_r(struct _reent *r, int fd)
   return 1;
 }
 
+/***************************************************************************/
+
+__attribute__((used))
+void _exit(int status) {
+
+  (void) status;
+
+  chSysHalt("exit");
+  abort();
+}
+
+/***************************************************************************/
+
+__attribute__((used))
+int _kill(int pid, int sig) {
+
+  (void) pid;
+  (void) sig;
+
+  chSysHalt("kill");
+  abort();
+}
+
+/***************************************************************************/
+
+__attribute__((used))
+int _getpid(void) {
+
+  return 1;
+  abort();
+}
+
+/***************************************************************************/
+/* Only used in C++ mode.*/
+void __cxa_pure_virtual(void) {
+  chSysHalt("pure virtual");
+}
+
 /*** EOF ***/


### PR DESCRIPTION
Fix a linker issue where certain systemcalls are not found.
As reported in https://forum.chibios.org/viewtopic.php?t=5868 the
sycalls.c is incomplete in oder ChibiOSes.

Copy the missing syscalls from ChibiOS 21.11.2's syscalls.c

Signed-off-by: Martin Gritzan <martin.gritzan@gmail.com>